### PR TITLE
feat(validation.md): add info about using multiple validators

### DIFF
--- a/guides/validation.md
+++ b/guides/validation.md
@@ -50,6 +50,19 @@ Within the handler you can get the validated value with `c.req.valid('form')`.
 
 Validation targets include `json`, `query`, `header`, `param` and `cookie` in addition to `form`.
 
+## Multiple validators
+You can also include multiple validators to validate different parts of request:
+```ts
+app.post(
+  '/posts/:id',
+  validator('param', ...),
+  validator('query', ...),
+  validator('json', ...),
+  (c) => {
+    //... 
+  }
+```
+
 ## With Zod
 
 You can use [Zod](https://zod.dev), one of third-party validators.


### PR DESCRIPTION
Currently, the documentation doesn't mention anything about using multiple validators in the same request handler. Yet I've just found out that one can include multiple validators for validating different parts of a request. Moreover, typesafety will also work:

```ts
app.get("/:id",
  zValidator("param", z.object({ id: z.string() })),
  zValidator("json", z.object({ name: z.string() })),
  //...
```